### PR TITLE
Automatically import all rapidez app.js files

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,2 +1,8 @@
-import 'Vendor/rapidez/core/resources/js/app.js'
-import 'Vendor/rapidez/account/resources/js/callbacks.js'
+import.meta.glob([
+    // Automatically import all installed Rapidez module scripts.
+    'Vendor/rapidez/*/resources/js/app.js',
+    // To exclude a specific file add the path with a !: (https://vitejs.dev/guide/features.html#negative-patterns)
+    // '!Vendor/rapidez/account/resources/js/app.js',
+    // Or to load all js files from another vendor: (https://vitejs.dev/guide/features.html#multiple-patterns)
+    // 'Vendor/<vendor>/*/resources/js/app.js',
+], { eager: true });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,8 +1,10 @@
+import './components.js'
+
 import.meta.glob([
     // Automatically import all installed Rapidez module scripts.
-    'Vendor/rapidez/*/resources/js/app.js',
+    'Vendor/rapidez/*/resources/js/package.js',
     // To exclude a specific file add the path with a !: (https://vitejs.dev/guide/features.html#negative-patterns)
-    // '!Vendor/rapidez/account/resources/js/app.js',
+    // '!Vendor/rapidez/account/resources/js/package.js',
     // Or to load all js files from another vendor: (https://vitejs.dev/guide/features.html#multiple-patterns)
-    // 'Vendor/<vendor>/*/resources/js/app.js',
+    // 'Vendor/<vendor>/*/resources/js/package.js',
 ], { eager: true });

--- a/resources/js/components.js
+++ b/resources/js/components.js
@@ -1,0 +1,12 @@
+(() => {
+    const components = {
+        // Eager load all components not ending with .lazy.vue
+        ...import.meta.glob(['./components/*.vue', '!./components/*.lazy.vue'], { eager: true, import: 'default' }),
+        // Lazy load all components not ending with .lazy.vue
+        ...import.meta.glob(['./components/*.lazy.vue'], { eager: false, import: 'default' })
+    };
+    for (const path in components) {
+        // Register component using their filename.
+        Vue.component(path.split('/').pop().split('.').shift(), components[path])
+    }
+})();

--- a/resources/js/components/README.md
+++ b/resources/js/components/README.md
@@ -1,14 +1,10 @@
 # Components
-This folder will contain your Vue components.
-Any .vue files present in this folder will be registered.
-any file a level deeper will not.
+
+This folder will contain your Vue components. Any `.vue` file present in this folder will be registered; any file a level deeper will not!
 
 ## Lazy loading
-Setting the file extension of your file in this folder as .lazy.vue will ensure that
-it is bundled separately and not included in the app.js bundle.
-Note that you do not deal with them differently than any other vue component.
-Though if you know it's going to be used above the fold on a page you can ensure it is preloaded on that page
-using the following
+
+Setting the file extension of your file in this folder as `.lazy.vue` will ensure that it is bundled separately and not included in the `app.js` bundle. Note that you do not deal with them differently than any other vue component. Though if you know it's going to be used above the fold on a page you can ensure it is preloaded on that page using the following:
 
 ```blade
 @pushOnce('head')
@@ -17,5 +13,5 @@ using the following
     @endif
 @endPushOnce
 ```
-https://github.com/rapidez/core/blob/7100cf6b130b7f9c3cdb0bce383524e57833272a/resources/views/components/listing.blade.php#L7
-This will ensure the file and it's dependencies are loaded as fast as possible.
+
+This will ensure the file and it's dependencies are loaded as fast as possible. We're using this in the `listing.blade.php`. See: https://github.com/rapidez/core/blob/master/resources/views/components/listing.blade.php

--- a/resources/js/components/README.md
+++ b/resources/js/components/README.md
@@ -1,0 +1,21 @@
+# Components
+This folder will contain your Vue components.
+Any .vue files present in this folder will be registered.
+any file a level deeper will not.
+
+## Lazy loading
+Setting the file extension of your file in this folder as .lazy.vue will ensure that
+it is bundled separately and not included in the app.js bundle.
+Note that you do not deal with them differently than any other vue component.
+Though if you know it's going to be used above the fold on a page you can ensure it is preloaded on that page
+using the following
+
+```blade
+@pushOnce('head')
+    @if($file = vite_filename_path('<filename_or_end_of_path>.vue'))
+        @vite([$file])
+    @endif
+@endPushOnce
+```
+https://github.com/rapidez/core/blob/7100cf6b130b7f9c3cdb0bce383524e57833272a/resources/views/components/listing.blade.php#L7
+This will ensure the file and it's dependencies are loaded as fast as possible.


### PR DESCRIPTION
This does need https://github.com/rapidez/account/pull/26 to be merged to automatically add account functionality.
Otherwise it should be imported in the way it is mentioned in the old readme