### PR TITLE
Add modules required for image resizing, initialize scheduler, build with default local proxies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,15 @@ ARG WWWGROUP
 
 WORKDIR /var/www/html
 
-RUN docker-php-ext-enable sodium
-RUN docker-php-ext-install exif pdo pdo_mysql
-
-RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
-    && apk add --update nodejs npm yarn
+RUN apk add --update libpng-dev jpeg-dev libwebp-dev freetype-dev libmcrypt-dev gd-dev jpegoptim optipng pngquant gifsicle \
+ && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp \
+ && docker-php-ext-enable sodium \
+ && docker-php-ext-install exif pdo pdo_mysql gd \
+ && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
+ && apk add --update nodejs npm yarn
 
 RUN composer create-project rapidez/rapidez . \
+    && echo "* * * * * cd /var/www/html && php artisan schedule:run" >> /etc/crontabs/root \
+    && sed -i 's/protected $proxies;/protected $proxies = ["127.0.0.1\/8","172.17.0.0\/14"];/g' app/Http/Middleware/TrustProxies.php \
     && php artisan rapidez:install \
     && yarn && yarn run prod


### PR DESCRIPTION
This ensures the image resizer module will work as expected within the container.
It will also make sure docker and local proxies can pass the X-Proto header to properly configure https in a default docker setup.