### PR TITLE
Workaround for Vite bug watching every page if you use negated patterns

### DIFF
--- a/resources/js/components.js
+++ b/resources/js/components.js
@@ -1,7 +1,7 @@
 (() => {
     const components = {
-        // Eager load all components not ending with .lazy.vue
-        ...import.meta.glob(['./components/*.vue', '!./components/*.lazy.vue'], { eager: true, import: 'default' }),
+        // Eager load all components not containing an extra . in the name
+        ...import.meta.glob(['./components/*([^\.]).vue'], { eager: true, import: 'default' }),
         // Lazy load all components not ending with .lazy.vue
         ...import.meta.glob(['./components/*.lazy.vue'], { eager: false, import: 'default' })
     };


### PR DESCRIPTION
This is a bug that exists in vite itself, causing it to reload on any change (e.g. `storage/framework` Laravel caching stuff being remade)