### PR TITLE
Revert workaround vite glob import

### DIFF
--- a/resources/js/components.js
+++ b/resources/js/components.js
@@ -1,7 +1,7 @@
 (() => {
     const components = {
-        // Eager load all components not containing an extra . in the name
-        ...import.meta.glob(['./components/**/*([^\.]).vue'], { eager: true, import: 'default' }),
+        // Eager load all components not ending with .lazy.vue
+        ...import.meta.glob(['./components/**/*.vue', '!./components/**/*.lazy.vue'], { eager: true, import: 'default' }),
         // Lazy load all components not ending with .lazy.vue
         ...import.meta.glob(['./components/**/*.lazy.vue'], { eager: false, import: 'default' })
     };
@@ -10,7 +10,7 @@
             .split('/').pop() // Remove directories
             .split('.').shift() // Remove extension
             .replace(/^.|[A-Z]/g, letter => `-${letter.toLowerCase()}`) // PascalCase to snake_case
-            .substr(1) // Remove the starting dash
+            .substring(1) // Remove the starting dash
 
         // Register component using their filename.
         Vue.component(componentName, components[path])


### PR DESCRIPTION
https://github.com/vitejs/vite/issues/13374
has since been fixed in 
https://github.com/vitejs/vite/pull/13646

Thus the workaround is no longer needed.