### PR TITLE
Don't push Docker containers on all branches

### DIFF
--- a/.github/workflows/push-docker-container.yml
+++ b/.github/workflows/push-docker-container.yml
@@ -10,7 +10,8 @@ on:
     - cron: '0 10 * * 1'
   push:
     branches:
-      - '*'
+      - master
+      - '*.x'
     tags:
       - '*'
 


### PR DESCRIPTION
For example; it's currently also running here: https://github.com/rapidez/rapidez/pull/85. I don't think we need it there.