### PR TITLE
[3.x] Symlink the postcss config as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "symlink-frontend": [
             "ln -s ../core/package.json package.json",
             "ln -s ../core/tailwind.config.js tailwind.config.js",
+            "ln -s ../core/postcss.config.js postcss.config.js",
             "ln -s ../core/vite.config.js vite.config.js"
         ]
     }


### PR DESCRIPTION
This is necessary for the css + tailwind to actually work.