### PR TITLE
[5.x] Add exception for config.js

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Crawl-delay: 1
+Allow: /config.js?
 Disallow: /*?
 Disallow: /account
 Disallow: /cart


### PR DESCRIPTION
The `/*?` rule blocked crawlers from accessing `config.js`. This meant that googlebot was unable to get any products on listing pages, for example. Pages got indexed with missing bits and pieces.

By adding the allow before the `/*?` rule it will match the allow rule first.