### PR TITLE
Temporarily disable serializable classes

### DIFF
--- a/.github/workflows/copy-laravel-source.yml
+++ b/.github/workflows/copy-laravel-source.yml
@@ -48,6 +48,10 @@ jobs:
           database/
           config/sanctum.php
 
+      - name: Apply temporary customisations
+        run: >
+          cd rapidez && sed -i -e "s/'serializable_classes' => false,/'serializable_classes' => null,/g" ./config/cache.php
+
       - name: Check if there are changes
         id: has-changes
         run: |

--- a/config/cache.php
+++ b/config/cache.php
@@ -131,6 +131,6 @@ return [
     |
     */
 
-    'serializable_classes' => false,
+    'serializable_classes' => null,
 
 ];


### PR DESCRIPTION
See:
[laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration](https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration)

Since Laravel 13 caching class instances are more complicated.

This means all code where Rapidez adds items to cache we will need to convert from and to a class-free structure instead. https://github.com/justbetter/laravel-http3earlyhints/pull/8 

This PR temporarily disables the feature so Rapidez can remain functional for now.