### PR TITLE
[5.x] Use ELASTICSEARCH_PASSWORD instead of ELASTICSEARCH_PASS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ELASTICSEARCH_HOST="localhost"
 ELASTICSEARCH_PORT=9200
 ELASTICSEARCH_SCHEME="http"
 ELASTICSEARCH_USER=elastic
-ELASTICSEARCH_PASS="changeme"
+ELASTICSEARCH_PASSWORD="changeme"
 ELASTICSEARCH_RAPIDEZ_PASS="rapidez"
 
 # This is used for communication from the website frontend, its important that the domain is reachable. localhost or 127.0.0.1 does not work.


### PR DESCRIPTION
Both work, but `ELASTICSEARCH_PASS` only gets used as fallback instead of as the "main" .env variable.