### PR TITLE
[5.x] Add default schedule for commands

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+Schedule::command('rapidez:index')->hourly()->withoutOverlapping();
+Schedule::command('rapidez:index:update')->everyMinute()->withoutOverlapping();
+
+Schedule::command('cache:clear')->daily();


### PR DESCRIPTION
ref: RAP-1989

This adds the indexer schedule that we already use for every new project to the default schedule of rapidez/rapidez. Also added the `cache:clear` command to be run daily, particularly useful for things like product attributes that get cached.